### PR TITLE
Run unbound-control-setup, in order to create the certificates

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class unbound::params {
       $package_name = 'unbound'
       $anchor_file  = "${confdir}/root.anchor"
       $owner        = 'unbound'
+      $group        = 'unbound'
       $fetch_client = 'wget -O'
     }
     'redhat', 'centos', 'scientific': {
@@ -21,6 +22,7 @@ class unbound::params {
       $package_name = 'unbound'
       $anchor_file  = "${confdir}/root.anchor"
       $owner        = 'unbound'
+      $group        = 'unbound'
       $fetch_client = 'wget -O'
       }
     'darwin': {
@@ -31,6 +33,7 @@ class unbound::params {
       $package_provider = 'macports'
       $anchor_file  = "${confdir}/root.anchor"
       $owner            = 'unbound'
+      $group            = 'unbound'
       $fetch_client     = 'curl -o'
     }
     'freebsd': {
@@ -40,6 +43,7 @@ class unbound::params {
       $package_name = 'dns/unbound'
       $anchor_file  = "${confdir}/root.anchor"
       $owner        = 'unbound'
+      $group        = 'unbound'
       $fetch_client = 'fetch -o'
     }
     'openbsd': {
@@ -53,6 +57,7 @@ class unbound::params {
       }
       $anchor_file  = "${confdir}/root.anchor"
       $owner        = '_unbound'
+      $group        = '_unbound'
       $fetch_client = 'ftp -o'
     }
     'sles', 'opensuse', 'suse': {
@@ -63,6 +68,7 @@ class unbound::params {
       $anchor_file    = '/var/lib/unbound/root.key'
       $owner          = 'unbound'
       $group          = 'unbound'
+      $group          = 'unbound'
       $pidfile        = '/var/run/unbound/unbound.pid'
     }
     default: {
@@ -72,6 +78,7 @@ class unbound::params {
       $package_name = 'unbound'
       $anchor_file  = "${confdir}/root.anchor"
       $owner        = 'unbound'
+      $group        = 'unbound'
       $fetch_client = 'wget -O'
     }
   }

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -21,4 +21,9 @@ class unbound::remote (
     target  => $config_file,
     content => template('unbound/remote.erb'),
   }
+
+  exec { 'unbound-control-setup':
+    command => 'unbound-control-setup -d /var/unbound/etc && chgrp _unbound /var/unbound/etc/unbound_*',
+    creates => '/var/unbound/etc/unbound_server.pem',
+  }
 }

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -6,11 +6,13 @@ class unbound::remote (
   $enable            = true,
   $interface         = ['::1', '127.0.0.1'],
   $port              = 953,
-  $server_key_file   = undef,
-  $server_cert_file  = undef,
-  $control_key_file  = undef,
-  $control_cert_file = undef
-) {
+  $server_key_file   = "${unbound::params::confdir}/unbound_server.key",
+  $server_cert_file  = "${unbound::params::confdir}/unbound_server.pem",
+  $control_key_file  = "${$unbound::params::confdir}/unbound_control.key",
+  $control_cert_file = "${$unbound::params::confdir}/unbound_control.pem",
+  $group             = $unbound::params::group,
+  $confdir           = $unbound::params::confdir,
+) inherits unbound::params {
 
   include unbound::params
 
@@ -23,7 +25,11 @@ class unbound::remote (
   }
 
   exec { 'unbound-control-setup':
-    command => 'unbound-control-setup -d /var/unbound/etc && chgrp _unbound /var/unbound/etc/unbound_*',
-    creates => '/var/unbound/etc/unbound_server.pem',
+    command => "unbound-control-setup -d ${confdir} && \
+		chgrp ${group} ${server_key_file} \
+			${server_cert_file} \
+			${control_key_file} \
+			${control_cert_file}",
+    creates => "${server_key_file}",
   }
 }

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -30,6 +30,6 @@ class unbound::remote (
 			${server_cert_file} \
 			${control_key_file} \
 			${control_cert_file}",
-    creates => "${server_key_file}",
+    creates => $server_key_file,
   }
 }

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -14,8 +14,6 @@ class unbound::remote (
   $confdir           = $unbound::params::confdir,
 ) inherits unbound::params {
 
-  include unbound::params
-
   $config_file = $unbound::params::config_file
 
   concat::fragment { 'unbound-remote':
@@ -25,11 +23,12 @@ class unbound::remote (
   }
 
   exec { 'unbound-control-setup':
-    command => "unbound-control-setup -d ${confdir} && \
-		chgrp ${group} ${server_key_file} \
-			${server_cert_file} \
-			${control_key_file} \
-			${control_cert_file}",
+    command => "unbound-control-setup -d ${confdir}",
     creates => $server_key_file,
+  } ->
+  file { [ $server_key_file, $server_cert_file, $control_key_file, $control_cert_file ]:
+    owner => 'root',
+    group => $group,
+    mode  => '0640',
   }
 }


### PR DESCRIPTION
for unbound-control. Seems to be required with unbound > 1.5

I updated one of my DNS servers today, and found unbound not starting up anymore automatically.
reason seems to be, that unbound-control now defaults to SSL secure communication.
However, its fairly hardcoded.

Do you think, unbound::remote should inherit unbound::params, and take the
group name, and $configdir from there?

