### PR TITLE
Exec calls should have a full path.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,7 @@ class unbound (
       ensure   => installed,
       provider => $package_provider,
     }
+    Package[$package_name] -> Service[$service_name]
     Package[$package_name] -> Concat[$config_file]
     Package[$package_name] -> File[$confdir]
     Package[$package_name] -> File[$conf_d]
@@ -85,10 +86,8 @@ class unbound (
     Package[$package_name] -> Exec['download-roothints']
     if($checkconf_enable) {
       Package[$package_name] -> Exec['checkconf']
-      Concat[$config_file] -> Exec['checkconf']
-      Exec['checkconf'] -> Service[$service_name]
-    } else {
-      Package[$package_name] -> Service[$service_name]
+      Concat[$config_file] ~> Exec['checkconf']
+      Exec['checkconf'] ~> Service[$service_name]
     }
   }
 
@@ -139,7 +138,7 @@ class unbound (
   }
 
   concat { $config_file:
-    notify  => Service[$service_name],
+    notify => Service[$service_name],
   }
 
   concat::fragment { 'unbound-header':
@@ -149,12 +148,6 @@ class unbound (
   }
 
   if($checkconf_enable) {
-    Concat[$config_file] {
-      notify => [
-        Service[$service_name],
-        Exec['checkconf'],
-      ]
-    }
     exec { 'checkconf':
       command     => $checkconf_path,
       refreshonly => true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,6 +91,7 @@ class unbound::params {
   $conf_d                     = "${confdir}/conf.d"
   $config_file                = "${confdir}/unbound.conf"
   $control_enable             = false
+  $control_setup_path		  = "/usr/sbin/unbound-control-setup"
   $directory                  = $confdir
   $dlv_anchor_file            = undef
   $do_ip4                     = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,6 +92,8 @@ class unbound::params {
   $config_file                = "${confdir}/unbound.conf"
   $control_enable             = false
   $control_setup_path		  = "/usr/sbin/unbound-control-setup"
+  $checkconf_enable           = false
+  $checkconf_path             = "/usr/sbin/unbound-checkconf"
   $directory                  = $confdir
   $dlv_anchor_file            = undef
   $do_ip4                     = true

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -23,7 +23,7 @@ class unbound::remote (
   }
 
   exec { 'unbound-control-setup':
-    command => "unbound-control-setup -d ${confdir}",
+    command => "${unbound::params::control_setup_path} -d ${confdir}",
     creates => $server_key_file,
   } ->
   file { [ $server_key_file, $server_cert_file, $control_key_file, $control_cert_file ]:

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -12,7 +12,7 @@ define unbound::stub (
   $config_file = $unbound::params::config_file
 
   concat::fragment { "unbound-stub-${name}":
-    order   => '05',
+    order   => '15',
     target  => $config_file,
     content => template('unbound/stub.erb'),
   }


### PR DESCRIPTION
Error: Failed to apply catalog: Validation of Exec[unbound-control-setup]
failed: 'unbound-control-setup -d /etc/unbound' is not qualified and no path
was specified. Please qualify the command or specify a path. at
.../modules/unbound/manifests/remote.pp:25

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>