### PR TITLE
unbound-checkconf: validate new conf before use

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,6 +91,8 @@ class unbound::params {
   $conf_d                     = "${confdir}/conf.d"
   $config_file                = "${confdir}/unbound.conf"
   $control_enable             = false
+  $checkconf_enable           = false
+  $checkconf_path             = '/usr/sbin/unbound-checkconf'
   $directory                  = $confdir
   $dlv_anchor_file            = undef
   $do_ip4                     = true


### PR DESCRIPTION
I managed to quietly break my unbound because of the merge order of
stubs; so add some validation now.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>