### PR TITLE
Ensure local-zone is always under server.

### DIFF
--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -12,7 +12,7 @@ define unbound::stub (
   $config_file = $unbound::params::config_file
 
   concat::fragment { "unbound-stub-${name}":
-    order   => '05',
+    order   => '15',
     target  => $config_file,
     content => template('unbound/stub.erb'),
   }


### PR DESCRIPTION
If you create resources with stub before local-zone, the local-zone
entries end up in the stubs, causing a validation failure.

To solve this, force the stubs to come later in the configuration file.

Example code to trigger the bug (with the hashes non-empty):
create_resources(unbound::stub, hiera_hash('unbound::zones::stub', {}), {})
create_resources(unbound::local_zone, hiera_hash('unbound::zones::local', {}), {})

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>