### PR TITLE
Exec calls should have a full path.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,6 +91,7 @@ class unbound::params {
   $conf_d                     = "${confdir}/conf.d"
   $config_file                = "${confdir}/unbound.conf"
   $control_enable             = false
+  $control_setup_path         = '/usr/sbin/unbound-control-setup'
   $directory                  = $confdir
   $dlv_anchor_file            = undef
   $do_ip4                     = true

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -23,7 +23,7 @@ class unbound::remote (
   }
 
   exec { 'unbound-control-setup':
-    command => "unbound-control-setup -d ${confdir}",
+    command => "${unbound::params::control_setup_path} -d ${confdir}",
     creates => $server_key_file,
   } ->
   file { [ $server_key_file, $server_cert_file, $control_key_file, $control_cert_file ]:


### PR DESCRIPTION
Error: Failed to apply catalog: Validation of Exec[unbound-control-setup]
failed: 'unbound-control-setup -d /etc/unbound' is not qualified and no path
was specified. Please qualify the command or specify a path. at
.../modules/unbound/manifests/remote.pp:25

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>