### PR TITLE
RedHat does not install wget by default, but curl is available

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class unbound::params {
       $runtime_dir  = $confdir
       $owner        = 'unbound'
       $group        = 'unbound'
-      $fetch_client = 'wget -O'
+      $fetch_client = 'curl -o'
     }
     'darwin': {
       $confdir          = '/opt/local/etc/unbound'


### PR DESCRIPTION
wget is not installed by default on a minimal RHEL install. Use curl (which is) instead.