### PR TITLE
Use the master branches status as build indicator

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Puppet powered DNS with Unbound
 
-[![Build Status](https://travis-ci.org/xaque208/puppet-unbound.png)](https://travis-ci.org/xaque208/puppet-unbound)
+[![Build Status](https://travis-ci.org/xaque208/puppet-unbound.svg?branch=master)](https://travis-ci.org/xaque208/puppet-unbound)
 
 A puppet module for the Unbound caching resolver.
 


### PR DESCRIPTION
Without this, the build indicator will flap on the latest build, which
may not be an accurate reflection of the code.  This is to keep the
build status accurate according to the master branch.