### PR TITLE
Removed unnecessary references to params to avoid inheritance issues

### DIFF
--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -7,9 +7,7 @@ define unbound::forward (
   $zone = $name,
 ) {
 
-  include unbound::params
-
-  $config_file = $unbound::params::config_file
+  $config_file = $unbound::config_file
 
   concat::fragment { "unbound-forward-${name}":
     order   => '20',

--- a/manifests/local_zone.pp
+++ b/manifests/local_zone.pp
@@ -19,9 +19,7 @@ define unbound::local_zone (
   $zone = $name,
 ) {
 
-  include unbound::params
-
-  $config_file = $unbound::params::config_file
+  $config_file = $unbound::config_file
 
   concat::fragment { "unbound-localzone-${name}":
     order   => '06',

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -10,9 +10,7 @@ define unbound::record (
   $entry   = $name
 ) {
 
-  include unbound::params
-
-  $config_file = $unbound::params::config_file
+  $config_file = $unbound::config_file
 
   $local_data     = "  local-data: \"${entry} ${ttl} IN ${type} ${content}\"\n"
   $local_data_ptr = "  local-data-ptr: \"${content} ${entry}\"\n"

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -6,15 +6,15 @@ class unbound::remote (
   $enable            = true,
   $interface         = ['::1', '127.0.0.1'],
   $port              = 953,
-  $server_key_file   = "${unbound::params::confdir}/unbound_server.key",
-  $server_cert_file  = "${unbound::params::confdir}/unbound_server.pem",
-  $control_key_file  = "${$unbound::params::confdir}/unbound_control.key",
-  $control_cert_file = "${$unbound::params::confdir}/unbound_control.pem",
-  $group             = $unbound::params::group,
-  $confdir           = $unbound::params::confdir,
-) inherits unbound::params {
+  $server_key_file   = "${unbound::confdir}/unbound_server.key",
+  $server_cert_file  = "${unbound::confdir}/unbound_server.pem",
+  $control_key_file  = "${unbound::confdir}/unbound_control.key",
+  $control_cert_file = "${unbound::confdir}/unbound_control.pem",
+  $group             = $unbound::group,
+  $confdir           = $unbound::confdir,
+) inherits unbound {
 
-  $config_file = $unbound::params::config_file
+  $config_file = $unbound::config_file
 
   concat::fragment { 'unbound-remote':
     order   => '10',

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -7,9 +7,7 @@ define unbound::stub (
   $insecure = false
 ) {
 
-  include unbound::params
-
-  $config_file = $unbound::params::config_file
+  $config_file = $unbound::config_file
 
   concat::fragment { "unbound-stub-${name}":
     order   => '15',


### PR DESCRIPTION
Pretty much that.  None of the sub classes should be called directly so $unbound:: is already in scope.  By calling or referring to unbound::params values defined when calling the unbound class are forgotten about. (e.g. an alternative $config_file).