### PR TITLE
Pin repo versions to aim for determinism

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,13 @@
 fixtures:
   repositories:
-    concat: git://github.com/puppetlabs/puppetlabs-concat.git
-    stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
-
+    stdlib:
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+      ref: '4.4.0'
+    concat:
+      repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
+      ref: '1.1.0'
+    file_concat:
+      repo: 'git://github.com/electrical/puppet-lib-file_concat.git'
+      ref: '1.0.1'
+  symlinks:
+    unbound: "#{source_dir}"


### PR DESCRIPTION
Tests running against unknown versions is a pain.  This simply pins the
versions of the required modules for testing to a specific version.