### PR TITLE
stub-zone could be specified with either ip or hostname

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ direct queries.
     }
 
     unbound::stub { "10.0.10.in-addr.arpa.":
-      hostname => [ 'ns1.example.com', 'ns2.example.com' ],
+      address => [ 'ns1.example.com', 'ns2.example.com', '10.0.0.10' ],
     }
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,11 @@ direct queries.
       address  => '10.0.0.10',
       insecure => true,
     }
+
+    unbound::stub { "10.0.10.in-addr.arpa.":
+      hostname => [ 'ns1.example.com', 'ns2.example.com' ],
+    }
+
 ```
 
 Unless you have DNSSEC for your private zones, they are considered insecure,

--- a/Readme.md
+++ b/Readme.md
@@ -55,8 +55,22 @@ direct queries.
       insecure => true,
     }
 
+    # port can be specified
+    unbound::stub { "0.0.10.in-addr.arpa.":
+      address  => '10.0.0.10@10053',
+      insecure => true,
+    }
+
+    # address can be an array.
+    # in the following case, generated conf would be as follows:
+    #
+    #   stub-host: ns1.example.com
+    #   stub-addr: 10.0.0.10@10053
+    #   stub-host: ns2.example.com
+    #
+    # note that conf will be generated in the same order provided.
     unbound::stub { "10.0.10.in-addr.arpa.":
-      address => [ 'ns1.example.com', 'ns2.example.com', '10.0.0.10' ],
+      address => [ 'ns1.example.com', '10.0.0.10@10053', 'ns2.example.com' ],
     }
 
 ```

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -4,6 +4,7 @@
 #
 define unbound::stub (
   $address,
+  $hostname,
   $insecure = false
 ) {
 

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -4,13 +4,8 @@
 #
 define unbound::stub (
   $address,
-  $hostname,
   $insecure = false
 ) {
-
-  if ! $address and ! $hostname {
-    fail('unbound::stub: either address or hostname must be specified.')
-  }
 
   include unbound::params
 

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -10,6 +10,7 @@ define unbound::stub (
   if ! $address {
     fail('unbound::stub: address(es) must be specified.')
   }
+  unbound::stub::validate_addr{ $address: }
 
   include unbound::params
 

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -7,6 +7,10 @@ define unbound::stub (
   $insecure = false
 ) {
 
+  if ! $address {
+    fail('unbound::stub: address(es) must be specified.')
+  }
+
   include unbound::params
 
   $config_file = $unbound::params::config_file

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -8,6 +8,10 @@ define unbound::stub (
   $insecure = false
 ) {
 
+  if ! $address and ! $hostname {
+    fail('unbound::stub: either address or hostname must be specified.');
+  }
+
   include unbound::params
 
   $config_file = $unbound::params::config_file

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -9,7 +9,7 @@ define unbound::stub (
 ) {
 
   if ! $address and ! $hostname {
-    fail('unbound::stub: either address or hostname must be specified.');
+    fail('unbound::stub: either address or hostname must be specified.')
   }
 
   include unbound::params

--- a/manifests/stub/validate_addr.pp
+++ b/manifests/stub/validate_addr.pp
@@ -1,0 +1,25 @@
+# Class: unbound::stub::validate_addr
+#
+# Validate address arg of unbound::stub
+#
+define unbound::stub::validate_addr {
+  $addr_arr = split($name, '@')
+
+  # check if the address arg is a valid ip address
+  if is_ip_address($addr_arr[0]) {
+
+    # multiple '@' signs invalid
+    if size($addr_arr) > 2 {
+      fail('unbound::stub: invalid address. too many at signs in it.')
+    }
+
+    # port num must be integer if exists
+    if size($addr_arr) == 2 and ! is_integer($addr_arr[1]) {
+      fail('unbound::stub: port num is invalid')
+    }
+
+  # address arg must be either ip address or hostname
+  } elsif ! is_domain_name($name) {
+    fail('unbound::stub: invalid address.')
+  }
+}

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -1,5 +1,12 @@
 stub-zone:
   name: "<%= @name %>"
+<% if @address -%>
 <% Array(@address).each do |addr| -%>
   stub-addr: <%= addr %>
+<% end -%>
+<% end -%>
+<% if @hostname -%>
+<% Array(@hostname).each do |host| -%>
+  stub-host: <%= host %>
+<% end -%>
 <% end -%>

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -2,10 +2,10 @@ stub-zone:
   name: "<%= @name %>"
 <% if @address -%>
 <% Array(@address).each do |addr| -%>
-<% if /\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\Z/ =~ addr -%>
-  stub-addr: <%= addr %>
-<% else -%>
+<% if is_domain_name(addr) -%>
   stub-host: <%= addr %>
+<% else -%>
+  stub-addr: <%= addr %>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -2,11 +2,10 @@ stub-zone:
   name: "<%= @name %>"
 <% if @address -%>
 <% Array(@address).each do |addr| -%>
+<% if /\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\Z/ =~ addr -%>
   stub-addr: <%= addr %>
+<% else -%>
+  stub-host: <%= addr %>
 <% end -%>
-<% end -%>
-<% if @hostname -%>
-<% Array(@hostname).each do |host| -%>
-  stub-host: <%= host %>
 <% end -%>
 <% end -%>

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -13,6 +13,10 @@ unbound::stub { '0.0.0.10.in-addr.arpa.':
   insecure => true,
 }
 
+unbound::stub { '10.0.10.in-addr.arpa.':
+  hostname => [ 'ns1.example.com', 'ns2.example.com' ],
+}
+
 unbound::local_zone { '10.in-addr.arpa.':
   type => 'nodefault'
 }

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -14,7 +14,7 @@ unbound::stub { '0.0.0.10.in-addr.arpa.':
 }
 
 unbound::stub { '10.0.10.in-addr.arpa.':
-  address => [ 'ns1.example.com', 'ns2.example.com', '10.0.0.10' ],
+  address => [ 'ns1.example.com', '10.0.0.10', 'ns2.example.com' ],
 }
 
 unbound::local_zone { '10.in-addr.arpa.':

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -14,7 +14,7 @@ unbound::stub { '0.0.0.10.in-addr.arpa.':
 }
 
 unbound::stub { '10.0.10.in-addr.arpa.':
-  hostname => [ 'ns1.example.com', 'ns2.example.com' ],
+  address => [ 'ns1.example.com', 'ns2.example.com', '10.0.0.10' ],
 }
 
 unbound::local_zone { '10.in-addr.arpa.':

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -13,8 +13,13 @@ unbound::stub { '0.0.0.10.in-addr.arpa.':
   insecure => true,
 }
 
+unbound::stub { '0.0.0.10.in-addr.arpa.':
+  address  => '10.0.0.10@10053',
+  insecure => true,
+}
+
 unbound::stub { '10.0.10.in-addr.arpa.':
-  address => [ 'ns1.example.com', '10.0.0.10', 'ns2.example.com' ],
+  address => [ 'ns1.example.com', '10.0.0.10@10053', 'ns2.example.com' ],
 }
 
 unbound::local_zone { '10.in-addr.arpa.':


### PR DESCRIPTION
This enables specifying stub zones with either or both of hostname(s) and ip address(s). We may want to create stub-zone settings in unbound.conf using ```stub-host:``` option in some case.

e.g. When using external nameserver services for some ip segment, it's likely that we would prefer specifying multiple name servers' hostnames to doing so with those ip addresses.