### PR TITLE
default port 8953 for remote-control

### DIFF
--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -5,7 +5,7 @@
 class unbound::remote (
   $enable            = true,
   $interface         = ['::1', '127.0.0.1'],
-  $port              = 953,
+  $port              = 8953,
   $server_key_file   = "${unbound::params::confdir}/unbound_server.key",
   $server_cert_file  = "${unbound::params::confdir}/unbound_server.pem",
   $control_key_file  = "${$unbound::params::confdir}/unbound_control.key",


### PR DESCRIPTION
It seems better to make default port number for remote-control correspond to that of [IANA ub-dns-control 8953/tcp](http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=8953) now that almost four years passed since [1.4.11 released](https://github.com/jedisct1/unbound/blob/master/doc/Changelog#L1605) in which [new default for the control-port config setting](https://github.com/jedisct1/unbound/blob/master/doc/Changelog#L1640) contained, plus this puppet module does not specify any unbound versions.