### PR TITLE
Bring back hide_version and hide_identity

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,8 @@ class unbound (
   $harden_dnssec_stripped       = $unbound::params::harden_dnssec_stripped,
   $harden_glue                  = $unbound::params::harden_glue,
   $harden_referral_path         = $unbound::params::harden_referral_path,
+  $hide_identity                = $unbound::params::hide_identity,
+  $hide_version                 = $unbound::params::hide_version,
   $hints_file                   = $unbound::params::hints_file,
   $infra_cache_slabs            = $unbound::params::infra_cache_slabs,
   $infra_host_ttl               = $unbound::params::infra_host_ttl,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,6 +119,8 @@ class unbound::params {
   $harden_dnssec_stripped     = true
   $harden_glue                = true
   $harden_referral_path       = true
+  $hide_identity              = true
+  $hide_version               = true
   $hints_file                 = "${confdir}/root.hints"
   $infra_cache_slabs          = undef
   $infra_host_ttl             = undef


### PR DESCRIPTION
This patch should bring back parameters that were already in the template ([ref](https://github.com/xaque208/puppet-unbound/blob/a1704870ba23068ab19b8b1765641344d6d399c0/templates/unbound.conf.erb#L141-L150)), but would always evaluate to a false-ish value without these present.

The parameters were (I assume accidentally) removed in #54 

Closes #90 