### PR TITLE
stub: local-zones have multiple types; allow type to be overwritten

### DIFF
--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -4,7 +4,8 @@
 #
 define unbound::stub (
   $address,
-  $insecure = false
+  $insecure = false,
+  $type     = 'transparent',
 ) {
 
   if ! $address {
@@ -35,6 +36,6 @@ define unbound::stub (
   concat::fragment { "unbound-stub-${name}-local-zone":
     order   => '02',
     target  => $config_file,
-    content => "  local-zone: \"${name}\" transparent \n",
+    content => "  local-zone: \"${name}\" ${type} \n",
   }
 }


### PR DESCRIPTION
This patch introduces the ability to overwrite `transparent` as a stub-zone (local-zone)'s type.

I ran into this when trying to configure a different type for my `local-zone`.

From the [unbound.conf](https://www.unbound.net/documentation/unbound.conf.html) docs, a `local-zone` may have many types.