### PR TITLE
Set correct checkconf on EL platforms

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class unbound::params {
       $group            = 'unbound'
       $pidfile          = undef
       $fetch_client     = 'curl -o'
-      $validate_cmd      = '/sbin/unbound-checkconf %'
+      $validate_cmd     = '/usr/sbin/unbound-checkconf %'
     }
     'darwin': {
       $confdir          = '/opt/local/etc/unbound'


### PR DESCRIPTION
Without this change, the path for EL systems is incorrect.  This has
been validated against EL 6.