### PR TITLE
Fix dependencies when using unbound::remote

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@ class unbound (
       restart   => 'unbound-control reload',
       require   => Class['unbound::remote'],
     }
-    Package[$package_name] -> Class['unbound::remote']
+    Package<| title == $package_name |> -> Class['unbound::remote']
     include unbound::remote
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,9 @@ class unbound (
   if $control_enable {
     Service[$service_name] {
       restart   => 'unbound-control reload',
+      require   => Class['unbound::remote'],
     }
+    Package[$package_name] -> Class['unbound::remote']
     include unbound::remote
   }
 


### PR DESCRIPTION
When first applying the manifest it's possible for the unbound::remote
class to be evaluated before the packages are installed or for the
service to be started before the remote management is configured.  This
addresses both issues.