### PR TITLE
Use the relative path for loading puppet_x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 language: ruby
 bundler_args: --without development
-before_install: rm Gemfile.lock || true
+before_install:
+  - rm Gemfile.lock || true
+  - gem update bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/puppet/parser/functions/validate_unbound_addr.rb
+++ b/lib/puppet/parser/functions/validate_unbound_addr.rb
@@ -1,4 +1,5 @@
-require 'puppet_x/unbound/validate_addrs'
+require_relative '../../../puppet_x/unbound/validate_addrs'
+
 
 Puppet::Parser::Functions.newfunction(:validate_unbound_addr) do |args|
   if (args.size != 1) then


### PR DESCRIPTION
This is to accommodate Puppetserver that doesn't currently assist in
dependency resolution.