### PR TITLE
Added missing option in the configuration: so_sndbuf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class unbound (
   $rrset_cache_slabs            = $unbound::params::rrset_cache_slabs,
   $service_name                 = $unbound::params::service_name,
   $so_rcvbuf                    = $unbound::params::so_rcvbuf,
+  $so_sndbuf                    = $unbound::params::so_sndbuf,
   $statistics_cumulative        = $unbound::params::statistics_cumulative,
   $statistics_interval          = $unbound::params::statistics_interval,
   $tcp_upstream                 = $unbound::params::tcp_upstream,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,6 +155,7 @@ class unbound::params {
   $rrset_cache_size           = undef
   $rrset_cache_slabs          = undef
   $so_rcvbuf                  = undef
+  $so_sndbuf                  = undef
   $statistics_cumulative      = false
   $statistics_interval        = 0
   $tcp_upstream               = false

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -127,6 +127,9 @@ server:
 <% if @so_rcvbuf -%>
   so-rcvbuf: <%= @so_rcvbuf %>
 <% end -%>
+<% if @so_sndbuf -%>
+  so-sndbuf: <%= @so_sndbuf %>
+<% end -%>
 <% if @tcp_upstream -%>
   tcp-upstream: yes
 <% end -%>


### PR DESCRIPTION
I am using this parameter and was missing it from the parameters list. I know there's a custom_server_conf option, but since you did declare so_rvcbuf, you should also define it's counterpart for consistency ;-)