### PR TITLE
Default behavior for unbound::remote isn't well documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ The Unbound remote controls the use of the unbound-control utility to
 issue commands to the Unbound daemon process.
 
 ```puppet
-    include unbound::remote
+    class { "unbound::remote":
+      enable => true,
+    }
 ```
 
 On some platforms this is needed to function correctly for things like service

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # [*enable*]
-#   (optional) The option is used to enable remote control, default is "yes".
+#   (optional) The option is used to enable remote control, default is false.
 #   If turned off, the server does not listen for  control.
 #
 # [*interface*]


### PR DESCRIPTION
Hi!

First, thanks for this module, it made installing and setting up unbound so much easier! I recently followed the directions on the README.md to enable unbound::remote and was disappointed that it didn't work when I followed the directions in README.md. I was also surprised when I found the documentation in /manifests/remote.pp not reflect what I found in /manifests/params.pp. I'm assuming the desired default behavior unboud::remote is to be disabled, and the documentation simply wasn't updated.

This PR tries to address this surprise by:

   * Updating README.md to have  a manifest snippet that "just works" for unbound::remote
   * Updating docs at the top of /manifests/remote.pp to properly reflect default vals.

Please let me know what y'all think.

Thanks!

Scott