### PR TITLE
fix extended_statistics setting

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,7 +111,7 @@ class unbound::params {
   $do_ip4                     = true
   $do_ip6                     = true
   $edns_buffer_size           = 1280
-  $extended_statistics        = no
+  $extended_statistics        = false
   $harden_below_nxdomain      = true
   $harden_dnssec_stripped     = true
   $harden_glue                = true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -106,4 +106,24 @@ describe 'unbound' do
       it { should contain_concat('/etc/unbound/unbound.conf.d/foobar.conf') }
     end
   end
+  context "custom extended_statistics passed to class" do
+    let (:facts) {{
+      :operatingsystem => 'Ubuntu',
+      :concat_basedir => '/dne'
+    }}
+    let (:params) {{
+      :extended_statistics => true,
+    }}
+    it { should contain_class('concat::setup') }
+    it { should contain_concat('/etc/unbound/unbound.conf') }
+    it { should contain_concat__fragment('unbound-header').with_content(
+        /^  extended-statistics: yes\n/
+    )}
+    context "with a different config file" do
+      before do
+        params.merge!({ :config_file => '/etc/unbound/unbound.conf.d/foobar.conf' })
+      end
+      it { should contain_concat('/etc/unbound/unbound.conf.d/foobar.conf') }
+    end
+  end
 end

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -6,7 +6,9 @@ server:
   auto-trust-anchor-file: <%= @auto_trust_anchor_file %>
   do-not-query-localhost: no
   use-syslog: yes
-  extended-statistics: <%= @extended_statistics %>
+<% if @extended_statistics -%>
+  extended-statistics: yes
+<% end -%>
   statistics-interval: <%= @statistics_interval %>
   root-hints: <%= @hints_file %>
 <% if @statistics_cumulative -%>


### PR DESCRIPTION
Right now `$extended_statistics` is set to the string `no`, this is put
in the the config file using `extended-statistics: <%=
@extended_statistics %>` .

If you try to set `$extended_statistics = yes` or `extended_statistics =
'yes'` in hiera, YAML(?) casts that as a boolean and the config file
gets generated as `extended-statistics: true` which causes unbound to
fail because it expects a `yes` or `no`.