### PR TITLE
Fix template variable reference

### DIFF
--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -97,11 +97,11 @@ server:
   access-control: <%= acc %> allow
 <% end -%>
 <% end -%>
-<% elsif access != '' -%>
-<% if access.include? " " -%>
-  access-control: <%= access %>
+<% elsif @access != '' -%>
+<% if @access.include? " " -%>
+  access-control: <%= @access %>
 <% else -%>
-  access-control: <%= access %> allow
+  access-control: <%= @access %> allow
 <% end -%>
 <% end -%>
 <% if @infra_host_ttl -%>


### PR DESCRIPTION
Without this change, on newer versions of Puppet, the variable 'access'
is not available within the scope.  Modifying to @access should correct
the problem to reference the scoped variable.