### PR TITLE
Add ability to set cache settings as parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class unbound (
   $val_permissive_mode          = $unbound::params::val_permissive_mode,
   $validate_cmd                 = $unbound::params::validate_cmd,
   $verbosity                    = $unbound::params::verbosity,
+  $cache_max_ttl                = $unbound::params::cache_max_ttl,
   $custom_server_conf           = $unbound::params::custom_server_conf,
   $skip_roothints_download      = $unbound::params::skip_roothints_download,
 ) inherits unbound::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,7 @@ class unbound (
   $validate_cmd                 = $unbound::params::validate_cmd,
   $verbosity                    = $unbound::params::verbosity,
   $cache_max_ttl                = $unbound::params::cache_max_ttl,
+  $cache_max_negative_ttl       = $unbound::params::cache_max_negative_ttl,
   $custom_server_conf           = $unbound::params::custom_server_conf,
   $skip_roothints_download      = $unbound::params::skip_roothints_download,
 ) inherits unbound::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,6 +155,7 @@ class unbound::params {
   $val_log_level              = 1
   $val_permissive_mode        = false
   $verbosity                  = 1
+  $cache_max_ttl              = undef
   $custom_server_conf         = []
   $skip_roothints_download    = false
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -156,6 +156,7 @@ class unbound::params {
   $val_permissive_mode        = false
   $verbosity                  = 1
   $cache_max_ttl              = undef
+  $cache_max_negative_ttl     = undef
   $custom_server_conf         = []
   $skip_roothints_download    = false
 }

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -176,6 +176,9 @@ server:
 <% if @cache_max_ttl -%>
   cache-max-ttl: <%= @cache_max_ttl %>
 <% end -%>
+<% if @cache_max_negative_ttl -%>
+  cache-max-negative-ttl: <%= @cache_max_negative_ttl %>
+<% end -%>
 <% @custom_server_conf.each do |c| -%>
   <%= c %>
 <% end -%>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -173,6 +173,9 @@ server:
 <% else -%>
   hide-version: no
 <% end -%>
+<% if @cache_max_ttl -%>
+  cache-max-ttl: <%= @cache_max_ttl %>
+<% end -%>
 <% @custom_server_conf.each do |c| -%>
   <%= c %>
 <% end -%>


### PR DESCRIPTION
This MR adds the ability to set two very widely modified config settings, `cache_max_ttl` and `cache_max_negative_tt`l.

While these can be set use `custom_server_conf` but I think these options are commonly enough that it's justifiable to add these as explicit options.