### PR TITLE
White space fix for puppet-lint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -188,4 +188,3 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -217,4 +217,3 @@ You can find more information about Unbound and its configuration items at
 ## Contribute
 
 Please help me make this module awesome!  Send pull requests and file issues.
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class unbound (
   } else {
     Exec['download-roothints'] -> File[$hints_file]
   }
-  
+
   file { [
     $confdir,
     $conf_d,
@@ -126,7 +126,7 @@ class unbound (
     path    => ['/usr/bin','/usr/local/bin'],
     before  => [ Concat::Fragment['unbound-header'] ],
   }
-  
+
   if $confdir == $runtime_dir {
     File[$confdir] {
       owner => $owner,

--- a/spec/unit/unbound/validate_addrs_spec.rb
+++ b/spec/unit/unbound/validate_addrs_spec.rb
@@ -75,4 +75,3 @@ describe 'PuppetX::Unbound::ValidateAddrs' do
     end
   end
 end
-


### PR DESCRIPTION
Just a couple of whitespace fixes for playing nicer with our, and probably others, linters.