### PR TITLE
Set hints permissions after download

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,8 +149,9 @@ class unbound (
   }
 
   file { $hints_file:
-    ensure => file,
-    mode   => '0444',
+    ensure  => file,
+    mode    => '0444',
+    require => Exec['download-roothints'],
   }
 
   concat { $config_file:


### PR DESCRIPTION
The package will usually contain a hints file, but the module will
download a new one.  We need to make sure the hints file is managed
after it's downloaded so that the runs are idempotent.