### PR TITLE
Remove dependency cycle when skip_roothints_download is true

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,8 +149,8 @@ class unbound (
   }
 
   file { $hints_file:
-    ensure  => file,
-    mode    => '0444',
+    ensure => file,
+    mode   => '0444',
   }
 
   concat { $config_file:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,6 @@ class unbound (
   file { $hints_file:
     ensure  => file,
     mode    => '0444',
-    require => Exec['download-roothints'],
   }
 
   concat { $config_file:


### PR DESCRIPTION
The requires for download-roothints and the hints file are set up earlier in
the file conditional on $skip_roothints_download specifying it again here
causes a dependency cycle.