### PR TITLE
Parameter to toggle DNSSEC

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,7 @@ unbound::validate_cmd: '/usr/sbin/unbound-checkconf %'
 unbound::access:
   - '::1'
   - '127.0.0.1/8'
+unbound::disable_dnssec: false
 unbound::auto_trust_anchor_file: "%{hiera('unbound::runtime_dir')}/root.key"
 unbound::anchor_fetch_command: "unbound-anchor -a %{hiera('unbound::auto_trust_anchor_file')}"
 unbound::chroot: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class unbound (
   Hash $stub                         = {},
   Hash $record                       = {},
   Array $access,
+  Boolean $disable_dnssec,
   String $anchor_fetch_command,
   String $auto_trust_anchor_file,
   Optional[String] $chroot,
@@ -143,14 +144,16 @@ class unbound (
     }
   }
 
-  exec { 'download-anchor-file':
-    command => $anchor_fetch_command,
-    creates => $auto_trust_anchor_file,
-    user    => $owner,
-    path    => ['/usr/sbin','/usr/local/sbin'],
-    returns => 1,
-    before  => [ Concat::Fragment['unbound-header'] ],
-    require => File[$runtime_dir],
+  if ! $disable_dnssec {
+    exec { 'download-anchor-file':
+      command => $anchor_fetch_command,
+      creates => $auto_trust_anchor_file,
+      user    => $owner,
+      path    => ['/usr/sbin','/usr/local/sbin'],
+      returns => 1,
+      before  => [ Concat::Fragment['unbound-header'] ],
+      require => File[$runtime_dir],
+    }
   }
 
   file { $hints_file:

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -2,8 +2,10 @@
 #
 server:
   verbosity: <%= @verbosity %>
+<% if !@disable_dnssec -%>
   trusted-keys-file: <%= @trusted_keys_file %>
   auto-trust-anchor-file: <%= @auto_trust_anchor_file %>
+<% end -%>
   do-not-query-localhost: no
   use-syslog: yes
 <% if @extended_statistics -%>
@@ -160,7 +162,7 @@ server:
 <% else -%>
   val-clean-additional: no
 <% end -%>
-<% if @val_permissive_mode -%>
+<% if @val_permissive_mode && !@disable_dnssec -%>
   # NOTE: TURNING THIS ON DISABLES ALL DNSSEC SECURITY
   val-permissive-mode: yes
 <% end -%>


### PR DESCRIPTION
The patch adds a Boolean $disable_dnssec (defaults to false), which prevents the trust anchors from being added to the config file, thus disabling DNSSEC. This is needed in a setup where validation is unfortunately still unavailable and unbound returns SERVFAIL with it enabled. According to [docs](https://www.unbound.net/documentation/howto_turnoff_dnssec.html), permissive mode doesn't actually disable validation, but ignores the result, so could be viewed as a performance hit in shops not using DNSSEC. 

I've created a 1.x branch to add the flag to the old syntax version as well, but I don't know if that is still supported.