### PR TITLE
Define local_zone via hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,32 @@ This means that your server will use the Google DNS servers for any
 zones that it doesn't know how to reach and cache the result.
 
 
+### Local Zones
+
+Configure a local zone. The type determines the answer  to  give
+if  there  is  no  match  from  local-data.  The types are deny,
+refuse, static, transparent, redirect, nodefault,  typetranspar-
+ent,  inform,  inform\_deny,  always\_transparent,  always\_refuse,
+always\_nxdomain.  See local-zone in the [unbound documentation](https://unbound.net/documentation/unbound.conf.html) 
+for more information.  You can configure a local-zone with something like the 
+following.
+
+```puppet
+puppet::local_zone {'10.0.10.in-addr.arpa.':
+  type => 'nodefault'
+}
+```
+
+Or, using hiera
+```yaml
+unbound::local_zone:
+  10.0.10.in-addr.arpa.:
+    type: nodefault
+  11.0.10.in-addr.arpa.:
+    type: nodefault
+```
+
+
 ### Fine grain access-control
 
 ```puppet

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,7 @@ unbound::validate_cmd: '/usr/sbin/unbound-checkconf %'
 unbound::forward: {}
 unbound::stub: {}
 unbound::record: {}
+unbound::local_zone: {}
 
 unbound::access:
   - '::1'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class unbound (
   Hash $forward,
   Hash $stub,
   Hash $record,
+  Hash $local_zone,
   Array $access,
   String $anchor_fetch_command,
   String $auto_trust_anchor_file,
@@ -181,6 +182,10 @@ class unbound (
 
   if $record {
     create_resources('unbound::record', $record)
+  }
+
+  if $local_zone {
+    create_resources('unbound::local_zone', $local_zone)
   }
 
 }

--- a/manifests/local_zone.pp
+++ b/manifests/local_zone.pp
@@ -18,9 +18,9 @@
 #   (optional) name of configuration file
 #
 define unbound::local_zone (
-  $type,
-  $zone = $name,
-  $config_file = $unbound::config_file,
+  Unbound::Local_zone_type $type,
+  String $zone = $name,
+  String $config_file = $unbound::config_file,
 ) {
 
   concat::fragment { "unbound-localzone-${name}":

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -103,6 +103,22 @@ describe 'unbound' do
         end
       end
 
+      context 'local_zone passed to class' do
+        let(:params) do
+          {
+            local_zone: { '0.0.10.in-addr.arpa.' => { 'type' => 'nodefault' } }
+          }
+        end
+        it { is_expected.to contain_class('concat::setup') }
+        it do
+          is_expected.to contain_concat__fragment(
+            'unbound-localzone-0.0.10.in-addr.arpa.'
+          ).with_content(
+            %r{^\s+local-zone: "0.0.10.in-addr.arpa." nodefault$}
+          )
+        end
+      end
+
       context 'custom extended_statistics passed to class' do
         let(:params) do
           {

--- a/spec/type_aliases/local_zone_type_spec.rb
+++ b/spec/type_aliases/local_zone_type_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Unbound::Local_zone_type' do
+    describe 'valid modes' do
+      %w(
+        deny refuse static transparent redirect nodefault typetransparent
+        inform inform_deny always_transparent always_refuse always_nxdomain
+      ).each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'invalid modes' do
+      context 'with garbage inputs' do
+        [
+          nil,
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'ネット',
+          '644',
+          '7777',
+          '1',
+          '22',
+          '333',
+          '55555',
+          '0x123',
+          '0649',
+          'deNy',
+          'refse',
+          'sta tic'
+        ].each do |value|
+          describe value.inspect do
+            it { is_expected.not_to allow_value(value) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/types/local_zone_type.pp
+++ b/types/local_zone_type.pp
@@ -1,0 +1,15 @@
+# custom enum type for local-zone types
+type Unbound::Local_zone_type = Enum[
+  'deny',
+  'refuse',
+  'static',
+  'transparent',
+  'redirect',
+  'nodefault',
+  'typetransparent',
+  'inform',
+  'inform_deny',
+  'always_transparent',
+  'always_refuse',
+  'always_nxdomain',
+]


### PR DESCRIPTION
Currently you can define stubs, forwards and access types via hiera however the local_zone type was missed.  this pull addresses that.  I have also updated the README, spec tests and added a custome type to validate the local-zone type