### PR TITLE
Update to hiera v5

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,14 +1,13 @@
 ---
-version: 4
-datadir: data
+version: 5
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
 hierarchy:
   - name: "release"
-    path: "os/%{facts.os.family}/%{facts.os.release.major}"
-    backend: yaml
+    path: "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
   - name: "family"
-    path: "os/%{facts.os.family}"
-    backend: yaml
+    path: "os/%{facts.os.family}.yaml"
   - name: "common"
-    backend: yaml
-    path: "common"
+    path: "common.yaml"
 

--- a/metadata.json
+++ b/metadata.json
@@ -94,7 +94,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0"
     }
   ],
   "description": "A module to deploy and manage the Unbound caching resolver",
@@ -107,6 +107,5 @@
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.13.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -32,7 +32,7 @@ hosts.each do |host|
     install_puppet_on(
       host,
       version: '4',
-      puppet_agent_version: '1.6.1',
+      puppet_agent_version: '1.9.0',
       default_action: 'gem_install'
     )
   end


### PR DESCRIPTION
This PR updates hiera.yaml to version 5 and removes the following warnings when running puppet 4.9+ :

Warning: Use of 'hiera.yaml' version 4 is deprecated. It should be converted to version 5
Warning: Defining "data_provider": "hiera" in metadata.json is deprecated.