### PR TITLE
Allow to set parameter forward-ssl-upstream for forward zones in

### DIFF
--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -23,15 +23,19 @@
 #   because the servers are unreachable, instead it is tried without this
 #   clause. The default is 'no'.
 #
+# [*forward_ssl_upstream*]
+#   (optional) If enabled, unbound will query the forward DNS server via TLS.
+#
 # [*config_file*]
 #   (optional) name of configuration file
 #
 define unbound::forward (
-  Array $address                   = [],
-  Array $host                      = [],
-  $zone                            = $name,
-  Pattern[/yes|no/] $forward_first = 'no',
-  $config_file                     = $unbound::config_file,
+  Array $address                          = [],
+  Array $host                             = [],
+  $zone                                   = $name,
+  Pattern[/yes|no/] $forward_first        = 'no',
+  Pattern[/yes|no/] $forward_ssl_upstream = 'no',
+  $config_file                            = $unbound::config_file,
 ) {
 
   concat::fragment { "unbound-forward-${name}":

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -92,13 +92,13 @@ describe 'unbound' do
       context 'forward passed to class' do
         let(:params) do
           {
-            forward: { 'example-forward.com' => { 'address' => ['10.0.0.1', '10.0.0.2'], 'forward_first' => 'yes' } }
+            forward: { 'example-forward.com' => { 'address' => ['10.0.0.1', '10.0.0.2'], 'forward_first' => 'yes', 'forward_ssl_upstream' => 'yes' } }
           }
         end
         it { is_expected.to contain_class('concat::setup') }
         it do
           is_expected.to contain_concat__fragment('unbound-forward-example-forward.com').with_content(
-            %r{^forward-zone:\n  name: "example-forward.com"\n  forward-addr: 10.0.0.1\n  forward-addr: 10.0.0.2\n  forward-first: yes}
+            %r{^forward-zone:\n  name: "example-forward.com"\n  forward-addr: 10.0.0.1\n  forward-addr: 10.0.0.2\n  forward-first: yes\n  forward-ssl-upstream: yes}
           )
         end
       end

--- a/templates/forward.erb
+++ b/templates/forward.erb
@@ -9,3 +9,6 @@ forward-zone:
 <% if @forward_first != 'no' -%>
   forward-first: <%= @forward_first %>
 <% end -%>
+<% if @forward_ssl_upstream != 'no' -%>
+  forward-ssl-upstream: <%= @forward_ssl_upstream %>
+<% end -%>


### PR DESCRIPTION
order to enable DNS via TLS.

This allows me to configure DNS via TLS for upstream resolvers i.e quad9 or cloudflare as well as having nsd running for local stub zones.

The test that tested for forward-first was enhanced to also include parameter forward_ssl_upstream