### PR TITLE
Include .sync.yml for lost beaker tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,28 @@
+---
+.travis.yml:
+  extras:
+    - rvm: 2.3
+      bundler_args: --without development
+      env: BEAKER_set=docker/ubuntu-14.04 CHECK=beaker
+      services: docker
+      sudo: required
+    - rvm: 2.3
+      bundler_args: --without development
+      env: BEAKER_set=docker/ubuntu-16.04 CHECK=beaker
+      services: docker
+      sudo: required
+    - rvm: 2.3
+      bundler_args: --without development
+      env: BEAKER_set=docker/centos-6 CHECK=beaker
+      services: docker
+      sudo: required
+    - rvm: 2.3
+      bundler_args: --without development
+      env: BEAKER_set=docker/centos-7 CHECK=beaker
+      services: docker
+      sudo: required
+    - rvm: 2.3
+      bundler_args: --without development
+      env: BEAKER_set=docker/debian-8 CHECK=beaker
+      services: docker
+      sudo: required


### PR DESCRIPTION
Without this change, the beaker testing was added manually, and not my
modulesync.  Here we add what should approximate to the changes that were lost
during the last sync.