### PR TITLE
Set unbound pidfile for 6.3

### DIFF
--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -1,5 +1,6 @@
 ---
 unbound::confdir: '/var/unbound/etc'
+unbound::pidfile: '/var/run/unbound.pid'
 unbound::logdir: '/var/log/unbound'
 unbound::owner: '_unbound'
 unbound::group: '_unbound'


### PR DESCRIPTION
Without this change, OpenBSD 6.3 has the incorrect pid file.