### PR TITLE
Fix regular expression in fact `unbound_version`.

### DIFF
--- a/lib/facter/unbound_version.rb
+++ b/lib/facter/unbound_version.rb
@@ -9,7 +9,7 @@ unbound_bin = case Facter.value('kernel')
 if File.exist? unbound_bin
   unbound_version = Facter::Util::Resolution.exec(
     "#{unbound_bin} -V 2>&1"
-  ).match(%r{\nVersion\s(\d\.\d\.\d)})[1]
+  ).match(%r{\nVersion\s+(\d+(?:\.\d+)*)})[1]
   Facter.add(:unbound_version) do
     setcode do
       unbound_version


### PR DESCRIPTION
`\d` matches a single digit, so a version like `1.4.20` will result in the fact `unbound_version` containing `1.4.2` instead of `1.4.20`. The new expression will match a number (one or more digits), followed by any number of dots which are immediately followed by a number. This way we're able to match `1`, `1.2`, `1.2.3`, `1.2.3.4` etc.