### PR TITLE
Change default interface value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache: bundler
 before_install:
   - 'rm -f Gemfile.lock'
   - 'gem update --system'
-  - 'gem install bundler'
 script:
   - 'bundle exec rake $CHECK'
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+Change default value for interface
+
 ## 2018-06-02 2.3.2
 Updates to modulesync_config, and ensure that unbound is restarted when the
 interface is changed, as a reload is insufficient.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,7 +5,7 @@ unbound::statistics_interval: ~
 unbound::extended_statistics: false
 unbound::num_threads: 1
 unbound::port: 53
-unbound::interface: ['::0','0.0.0.0']
+unbound::interface: ~
 unbound::interface_automatic: false
 unbound::outgoing_interface: ~
 unbound::outgoing_range: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class unbound (
   Boolean                                              $extended_statistics,
   Integer[1]                                           $num_threads,
   Integer[0, 65535]                                    $port,
-  Array[String]                                        $interface,
+  Optional[Array[String]]                              $interface,
   Boolean                                              $interface_automatic,
   Optional[Array[String]]                              $outgoing_interface,           # version 1.5.10
   Optional[Integer[1]]                                 $outgoing_range,
@@ -219,7 +219,7 @@ class unbound (
     file {"${confdir}/interfaces.txt":
       ensure  => file,
       notify  => Exec[$restart_cmd],
-      content => "# Used by puppet-unbound\n${interface.join('\n')}",
+      content => template('unbound/interfaces.txt.erb'),
     }
     exec {$restart_cmd:
       refreshonly => true,

--- a/templates/interfaces.txt.erb
+++ b/templates/interfaces.txt.erb
@@ -1,0 +1,7 @@
+# Used by puppet-unbound
+<% unless @interface.nil? -%>
+<%= @interface.join("\n") %>
+<% else -%>
+<%= String.new %>
+<% end -%>
+


### PR DESCRIPTION
In order to follow the unbound default, here we cease to require that an
interface is passed to the module.  Instead, we allow this parameter to be
optional.  When set, this parameter behaves just as it did before.  When the
user does not provide this value, the defaults are no longer passed in, and thus
absent from the configuration file on disk resulting in the default values
coming from unbound.conf(5) which is to listen on localhost.