### PR TITLE
Add SmartOS support #184

### DIFF
--- a/data/os/Solaris/SmartOS.yaml
+++ b/data/os/Solaris/SmartOS.yaml
@@ -1,0 +1,10 @@
+---
+unbound::confdir: '/opt/local/etc/unbound'
+unbound::pidfile: '/usr/local/etc/unbound/unbound.pid'
+unbound::logdir: '/var/log/unbound'
+unbound::fetch_client: 'wget -O'
+unbound::control_setup_path: '/opt/local/sbin/unbound-control-setup'
+unbound::control_path: '/opt/local/sbin/unbound-control'
+unbound::validate_cmd: '/opt/local/sbin/unbound-checkconf %'
+unbound::restart_cmd: "/usr/sbin/svcadm restart %{hiera('unbound::service_name')}"
+unbound::anchor_fetch_command: "/opt/local/sbin/unbound-anchor -a %{hiera('unbound::auto_trust_anchor_file')}"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,6 +6,8 @@ defaults:
 hierarchy:
   - name: "release"
     path: "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+  - name: "variant"
+    path: "os/%{facts.os.family}/%{facts.os.name}.yaml"
   - name: "family"
     path: "os/%{facts.os.family}.yaml"
   - name: "common"


### PR DESCRIPTION
Relates to #184, adds SmartOS support.

hiera.yaml tweak was required to differentiate between Solaris and SmartOS.