### PR TITLE
Issue 199: add version checking for ssl/tls parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,15 +46,15 @@ class unbound (
   Boolean                                              $do_udp,
   Boolean                                              $do_tcp,
   Optional[Integer[0]]                                 $tcp_mss,                      # version 1.5.8
-  Optional[Stdlib::Absolutepath]                       $tls_cert_bundle,
-  Boolean                                              $tls_upstream,
+  Optional[Stdlib::Absolutepath]                       $tls_cert_bundle,              # version 1.7.0
+  Boolean                                              $tls_upstream,                 # version 1.7.0
   Optional[Integer[0]]                                 $outgoing_tcp_mss,             # version 1.5.8
   Boolean                                              $tcp_upstream,
   Boolean                                              $udp_upstream_without_downstream,
-  Boolean                                              $ssl_upstream,
-  Optional[Stdlib::Absolutepath]                       $ssl_service_key,
-  Optional[Stdlib::Absolutepath]                       $ssl_service_pem,
-  Optional[Integer[0,65535]]                           $ssl_port,
+  Boolean                                              $ssl_upstream,                 # version 1.7.0
+  Optional[Stdlib::Absolutepath]                       $ssl_service_key,              # version 1.7.0
+  Optional[Stdlib::Absolutepath]                       $ssl_service_pem,              # version 1.7.0
+  Optional[Integer[0,65535]]                           $ssl_port,                     # version 1.7.0
   Boolean                                              $use_systemd,                  # version 1.6.1
   Boolean                                              $do_daemonize,
   Optional[Hash[String, Unbound::Access_control]]      $access_control,               # version 1.5.10

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -79,12 +79,12 @@ server:
 <%= print_config('outgoing-tcp-mss', @outgoing_tcp_mss, '1.5.8') -%>
 <%= print_config('tcp-upstream', @tcp_upstream) -%>
 <%= print_config('udp-upstream-without-downstream', @udp_upstream_without_downstream, '1.6.7') -%>
-<%= print_config('tls-upstream', @tls_upstream) -%>
-<%= print_config('tls-cert-bundle', @tls_cert_bundle) -%>
-<%= print_config('ssl-upstream', @ssl_upstream) -%>
-<%= print_config('ssl-service_key', @ssl_service_key) -%>
-<%= print_config('ssl-service_pem', @ssl_service_pem) -%>
-<%= print_config('ssl-port', @ssl_port) -%>
+<%= print_config('tls-upstream', @tls_upstream, '1.7.0') -%>
+<%= print_config('tls-cert-bundle', @tls_cert_bundle, '1.7.0') -%>
+<%= print_config('ssl-upstream', @ssl_upstream, '1.7.0') -%>
+<%= print_config('ssl-service_key', @ssl_service_key, '1.7.0') -%>
+<%= print_config('ssl-service_pem', @ssl_service_pem, '1.7.0') -%>
+<%= print_config('ssl-port', @ssl_port, '1.7.0') -%>
 <%= print_config('use-systemd', @use_systemd, '1.6.1') -%>
 <%= print_config('do-daemonize', @do_daemonize) -%>
 <% @access.each do |acc| -%>


### PR DESCRIPTION
As far as i can tell theses parameters where added in 1.7.0 

fixes #199 