### PR TITLE
Fix neg-cache-size in unbound.conf

### DIFF
--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -181,7 +181,7 @@ server:
 <%= print_config('permit-small-holddown', @permit_small_holddown, '1.5.5') -%>
 <%= print_config('key-cache-size', @key_cache_size) -%>
 <%= print_config('key-cache-slabs', @key_cache_slabs) -%>
-<%= print_config('neg-cache-slabs', @neg_cache_size) -%>
+<%= print_config('neg-cache-size', @neg_cache_size) -%>
 <%= print_config('unblock-lan-zones', @unblock_lan_zones, '1.5.0') -%>
 <%= print_config('insecure-lan-zones', @insecure_lan_zones, '1.5.8') -%>
 <%- if @local_zone -%>


### PR DESCRIPTION
The config key of `neg-cache-slabs` does not exist in [unbound.conf(5)](https://nlnetlabs.nl/documentation/unbound/unbound.conf/), and the service fails to start if it is present. I believe this to be a typo and that the key of `neg-cache-size` should be used, especially since that is the parameter that is being passed in.

```
Error: Execution of '/usr/sbin/unbound-checkconf /etc/unbound/unbound.conf20190826-27124-6oiy2x' returned 1: /etc/unbound/unbound.conf20190826-27124-6oiy2x:83: error: unknown keyword 'neg-cache-slabs'
```

This comes from unbound-1.6.6.1-el7.x86_64 and an internal repackage of 1.5.9.1-el6.x86_64