### PR TITLE
stop managing system directories like /run

### DIFF
--- a/data/os/Debian/6.yaml
+++ b/data/os/Debian/6.yaml
@@ -1,0 +1,2 @@
+---
+unbound::pidfile: '/var/run/unbound.pid'

--- a/data/os/Debian/8.yaml
+++ b/data/os/Debian/8.yaml
@@ -1,0 +1,2 @@
+---
+unbound::pidfile: '/var/run/unbound.pid'

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,10 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8",
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,7 +10,7 @@ describe 'unbound' do
       case facts[:os]['family']
       when 'Debian'
         pidfile = case facts[:os]['release']['major']
-                  when '7'
+                  when '6', '7', '8'
                     '/var/run/unbound.pid'
                   else
                     '/run/unbound.pid'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,34 +5,36 @@ describe 'unbound' do
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
+      pidfile = nil
+
       case facts[:os]['family']
       when 'Debian'
-        case facts[:os]['release']['major']
-        when '7'
-          let(:pidfile) { '/var/run/unbound.pid' }
-        else
-          let(:pidfile) { '/run/unbound.pid' }
-        end
+        pidfile = case facts[:os]['release']['major']
+                  when '7'
+                    '/var/run/unbound.pid'
+                  else
+                    '/run/unbound.pid'
+                  end
         let(:service) { 'unbound' }
         let(:conf_dir) { '/etc/unbound' }
       when 'RedHat'
-        let(:pidfile) { '/var/run/unbound/unbound.pid' }
+        pidfile = '/var/run/unbound/unbound.pid'
         let(:service) { 'unbound' }
         let(:conf_dir) { '/etc/unbound' }
       when 'OpenBSD'
-        let(:pidfile) { '/var/run/unbound.pid' }
+        pidfile = '/var/run/unbound.pid'
         let(:service) { 'unbound' }
         let(:conf_dir) { '/var/unbound/etc' }
       when 'FreeBSD'
-        let(:pidfile) { '/usr/local/etc/unbound/unbound.pid' }
+        pidfile = '/usr/local/etc/unbound/unbound.pid'
         let(:service) { 'unbound' }
         let(:conf_dir) { '/usr/local/etc/unbound' }
       when 'Darwin'
-        let(:pidfile) { '/var/run/unbound.pid' }
+        pidfile = '/var/run/unbound.pid'
         let(:service) { 'org.macports.unbound' }
         let(:conf_dir) { '/opt/local//etc/unbound' }
       else
-        let(:pidfile) { '/var/run/unbound/unbound.pid' }
+        pidfile = '/var/run/unbound/unbound.pid'
         let(:service) { 'unbound' }
         let(:conf_dir) { '/etc/unbound' }
       end
@@ -56,6 +58,11 @@ describe 'unbound' do
         it { is_expected.to contain_file(conf_d_dir) }
         it { is_expected.to contain_file(keys_d_dir) }
         it { is_expected.to contain_file(hints_file) }
+        it { is_expected.not_to contain_file('/run') }
+        it { is_expected.not_to contain_file('/var/run') }
+        if pidfile =~ %r{unbound/unbound\.pid\Z}
+          it { is_expected.to contain_file(File.dirname(pidfile)) }
+        end
         it do
           is_expected.to contain_concat__fragment(
             'unbound-header'


### PR DESCRIPTION
This is similar to #202, but simpler.

I had to declare the newer Debian versions to exercise the unit tests on them.

(Nevermind these acceptance results on my comp, you have Travis set up - The acceptance tests run successfully on Debian 8 and 9. The puppet agent does not install on Debian 10 nor Ubuntu 18 and I didn't bother to debug it. The tests fail on CentOS 7 because there is no `dnsutils` package available.)